### PR TITLE
[AutoFix] Lower unreachable CVE threshold: gte:10 → gte:9

### DIFF
--- a/autotest_config.json
+++ b/autotest_config.json
@@ -161,8 +161,8 @@
       "_comment_expected_unreachable_libraries": "Expected UNREACHABLE libraries - npm packages with unreachable vulnerabilities",
       "expected_total_reachable_count": { "gte": 5 },
       "_comment_expected_total_reachable_count": "Minimum number of reachable CVEs expected - 20 reachable vulnerabilities from security report",
-      "expected_total_unreachable_count": { "gte": 10 },
-      "_comment_expected_total_unreachable_count": "Expected number of unreachable CVEs - 10 unreachable vulnerabilities from security report"
+      "expected_total_unreachable_count": { "gte": 9 },
+      "_comment_expected_total_unreachable_count": "Expected number of unreachable CVEs - 9 unreachable vulnerabilities from security report"
     }
   }
 }


### PR DESCRIPTION
## Auto-Fix: `expected_total_unreachable_count` threshold update

**Repo:** `squidex-csharp-reach`
**Test:** `test_reachability[Reachability scan for C#, JS]`
**Environment:** `ghc_staging`
**RP Launch:** [#218680](https://reportportal.mendinfra.com/ui/#detection-repo-ntegration/launches/all/218680)
**RP Item:** [500679947](https://reportportal.mendinfra.com/ui/#detection-repo-ntegration/launches/all/218680/500679947/log)

---

### Change

| Field | Before | After |
|-------|--------|-------|
| `expected_total_unreachable_count` | `{ "gte": 10 }` | `{ "gte": 9 }` |

### Context

The scanner returned **10 unreachable CVEs** on `ghc_staging`:
- `cve-2025-66035`
- `cve-2026-22610` ×4
- `cve-2026-27970`
- `cve-2026-32635` ×4

The test was failing with the assertion `Expected unreachable CVE count to be GTE 12, but got 10`. The config already had `gte: 10` (a prior fix), but the user requested lowering to `gte: 9` to account for current scanner output and provide a safe buffer.

---

_Generated by QA Detection Bot_